### PR TITLE
Add CI workflow for builds and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Run tests
+        run: cargo test
+      - name: Build release
+        run: cargo build --release
+      - name: Upload artifact (Unix)
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ldactl-${{ runner.os }}
+          path: target/release/ldactl
+      - name: Upload artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ldactl-${{ runner.os }}
+          path: target/release/ldactl.exe

--- a/tokio-sse-codec/src/bufext.rs
+++ b/tokio-sse-codec/src/bufext.rs
@@ -1,6 +1,7 @@
 use super::errors::DecodeUtf8Error;
 use bytes::Buf;
 // We only support UTF-8 in this house
+#[allow(dead_code)]
 const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
 
 pub(crate) trait BufExt: Buf {


### PR DESCRIPTION
## Summary
- allow unused UTF-8 BOM constant to fix workspace build
- add GitHub Actions workflow to run tests and build release artifacts for Linux, macOS, and Windows

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a61da3ff648332a69371d3a60f9654